### PR TITLE
list_all_orders fn now returns expanded values

### DIFF
--- a/views/orders_view.py
+++ b/views/orders_view.py
@@ -16,8 +16,24 @@ def list_all_orders():
             o.jewelryId,
             o.metalId,
             o.sizeId,
-            o.styleId
+            o.styleId,
+            s.id AS size_id,
+            s.carets,
+            s.price AS size_price,
+            st.id AS style_id,
+            st.style,
+            st.price AS style_price,
+            m.id AS metal_id,
+            m.metal,
+            m.price AS metal_price,
+            j.id AS jewelry_id,
+            j.type,
+            j.price AS jewelry_price
         FROM Orders o
+        JOIN Sizes s ON s.id = o.sizeId
+        JOIN Style st ON st.id = o.styleId
+        JOIN Metals m ON m.id = o.metalId
+        JOIN Jewelry j ON j.id = o.jewelryId
         """
         )
         query_results = db_cursor.fetchall()
@@ -25,7 +41,36 @@ def list_all_orders():
         # Initialize an empty list and then add each dictionary to it
         orders = []
         for row in query_results:
-            orders.append(dict(row))
+
+            order = {
+                "id": row["id"],
+                "jewelry_id": row["jewelryId"],
+                "metal_id": row["metalId"],
+                "size_id": row["sizeId"],
+                "style_id": row["styleId"],
+                "size": {
+                    "id": row["size_id"],
+                    "carets": row["carets"],
+                    "price": row["size_price"],
+                },
+                "style": {
+                    "id": row["style_id"],
+                    "style": row["style"],
+                    "price": row["style_price"],
+                },
+                "metal": {
+                    "id": row["metal_id"],
+                    "metal": row["metal"],
+                    "price": row["metal_price"],
+                },
+                "jewelry": {
+                    "id": row["jewelry_id"],
+                    "type": row["type"],
+                    "price": row["jewelry_price"],
+                },
+            }
+
+            orders.append(order)
 
         # Serialize Python list to JSON encoded string
         serialized_orders = json.dumps(orders)


### PR DESCRIPTION
# Description

Converted the `list_all_orders` function to show expanded values. This includes detailed information about the size, style, metal, and jewelry associated with each order. The function now joins multiple tables to fetch and display these expanded values.

Fixes #123 (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [x] New feature

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors

# How Should I Test This?

Please describe the steps required to verify your changes. Provide instructions so your teammate can reproduce.

- [ ] Step 1: Run the server and ensure it starts without errors.
- [ ] Step 2: Make a GET request to the endpoint that calls `list_all_orders`.
- [ ] Step 3: Verify that the response includes expanded values for size, style, metal, and jewelry.